### PR TITLE
Fix compatibility with NL 9.1 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can specify which metrics you want to retrieve from AppDynamics among all av
 | AppDynamics | Tested with versions 4.4 and 4.5
 | Requirements | <ul><li>License FREE edition, or Enterprise edition, or Professional with Integration & Advanced Usage</li><li>AppDynamics account with Infrastructures and Plugins</li></ul>|
 | Bundled in NeoLoad | No |
-| Download Binaries    | <ul><li>[latest release](https://github.com/Neotys-Labs/AppDynamics/releases/latest) is only compatible with NeoLoad from version 6.7</li><li> Use this [release](https://github.com/Neotys-Labs/AppDynamics/releases/tag/1.0.0) for previous NeoLoad versions</li></ul>|
+| Download Binaries    | <ul><li>[latest release](https://github.com/Neotys-Labs/AppDynamics/releases/latest) is only compatible with NeoLoad from version 9.1</li><li> Use [this release 2.0.1](https://github.com/Neotys-Labs/AppDynamics/releases/tag/Neotys-Labs%2FAppDynamics.git-2.0.1) for NeoLoad 6.7 to 9.0</li><li> Use [this release 1.0.0](https://github.com/Neotys-Labs/AppDynamics/releases/tag/1.0.0) for previous NeoLoad versions</li></ul> |
 
 
 ## Installation
@@ -132,6 +132,7 @@ To ensure connectivity and test authorization to AppDynamics API server, you can
 When configuring SSO SaaS, the `HTTP 401 Unauthorized` error is returned if an API token has not been provided. Please specify a valid **appDynamicsAPIKey** token in the parameters of the AppDynamics action.
 
 ## ChangeLog
-* Version 1.0.0 (September 15, 2018): Initial release.
-* Version 2.0.0 (December 5, 2018): Make the **dataExchangeApiUrl** parameter optional.
+* Version 3.0.0 (January 10, 2022): Update version of NeoLoad DataExchange API client that is now compatible with java modules. Bump dependencies.
 * Version 2.0.1 (February 5, 2019): Update a dependency.
+* Version 2.0.0 (December 5, 2018): Make the **dataExchangeApiUrl** parameter optional.
+* Version 1.0.0 (September 15, 2018): Initial release.

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.1</version>
+            <version>4.5.13</version>
             <!-- already in NeoLoad: can cause conflicts -->
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <swagger-core-version>1.5.12</swagger-core-version>
         <okhttp-version>2.7.5</okhttp-version>
-        <gson-version>2.8.5</gson-version>
+        <gson-version>2.8.9</gson-version>
         <jodatime-version>2.9.3</jodatime-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.neotys.appdynamics</groupId>
     <artifactId>appdynamics-integration</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <properties>
         <swagger-core-version>1.5.12</swagger-core-version>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.neotys.rest</groupId>
             <artifactId>neotys-rest-api-dataexchange-client-olingo</artifactId>
-            <version>1.0.4</version>
+            <version>1.1.1</version>
             <!-- already in NeoLoad: can cause conflicts -->
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/com/neotys/appdynamics/AppDynamicsActionEngine.java
+++ b/src/main/java/com/neotys/appdynamics/AppDynamicsActionEngine.java
@@ -11,7 +11,7 @@ import com.neotys.extensions.action.engine.Context;
 import com.neotys.extensions.action.engine.Proxy;
 import com.neotys.extensions.action.engine.SampleResult;
 import com.neotys.rest.dataexchange.client.DataExchangeAPIClient;
-import com.neotys.rest.dataexchange.client.DataExchangeAPIClientFactory;
+import com.neotys.rest.dataexchange.client.olingo.DataExchangeAPIClientFactory;
 import com.neotys.rest.dataexchange.model.ContextBuilder;
 import com.neotys.rest.dataexchange.model.Entry;
 


### PR DESCRIPTION
This commit fixed LOAD-27930 [NLG] Custom actions using the data exchange API no longer work
This is a breaking change, and it will not be retro compatible with NL 9.0 and lower

- bump dependency for apache httpclient
- Build passed on jenkins-public